### PR TITLE
GH-754 Fix request parameter parsing

### DIFF
--- a/aws-serverless-java-container-springboot3/src/test/java/com/amazonaws/serverless/proxy/spring/servletapp/ServletApplication.java
+++ b/aws-serverless-java-container-springboot3/src/test/java/com/amazonaws/serverless/proxy/spring/servletapp/ServletApplication.java
@@ -1,9 +1,13 @@
 package com.amazonaws.serverless.proxy.spring.servletapp;
 
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.boot.web.servlet.support.SpringBootServletInitializer;
-import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 
 @SpringBootApplication(exclude = {
         org.springframework.boot.autoconfigure.security.reactive.ReactiveUserDetailsServiceAutoConfiguration.class,
@@ -14,5 +18,15 @@ import org.springframework.context.annotation.Import;
         org.springframework.boot.autoconfigure.orm.jpa.HibernateJpaAutoConfiguration.class
 })
 @Import(MessageController.class)
+@RestController
 public class ServletApplication {
+	
+	@RequestMapping(path = "/foo/{gender}/list/{age}", method = RequestMethod.POST, produces = MediaType.APPLICATION_JSON_VALUE)
+    public String complexRequest(
+            @PathVariable("gender") String gender,
+            @PathVariable("age") String age,
+            @RequestParam("name") String name
+    ) {
+		return gender + "/" + age + "/" + name;
+	}
 }

--- a/samples/springboot3/alt-pet-store/README.md
+++ b/samples/springboot3/alt-pet-store/README.md
@@ -37,3 +37,20 @@ PetStoreApi - URL for application            https://xxxxxxxxxx.execute-api.us-w
 
 $ curl https://xxxxxxxxxx.execute-api.us-west-2.amazonaws.com/pets
 ```
+
+You can also try a complex request passing both path and request parameters to  complex endpoint such as this:
+
+
+```
+@RequestMapping(path = "/foo/{gender}/bar/{age}", method = RequestMethod.POST, produces = MediaType.APPLICATION_JSON_VALUE)
+public String complexRequest(@RequestBody String body,
+        @PathVariable("gender") String gender,
+        @PathVariable("age") String age,
+        @RequestParam("name") String name
+)
+```
+For example.
+
+```
+curl -d '{"key1":"value1", "key2":"value2"}' -H "Content-Type: application/json" -X POST https://zuhd709386.execute-api.us-east-2.amazonaws.com/foo/male/bar/25?name=Ricky
+```

--- a/samples/springboot3/alt-pet-store/src/main/java/com/amazonaws/serverless/sample/springboot3/controller/PetsController.java
+++ b/samples/springboot3/alt-pet-store/src/main/java/com/amazonaws/serverless/sample/springboot3/controller/PetsController.java
@@ -17,6 +17,8 @@ package com.amazonaws.serverless.sample.springboot3.controller;
 import com.amazonaws.serverless.sample.springboot3.model.Pet;
 import com.amazonaws.serverless.sample.springboot3.model.PetData;
 
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
@@ -32,6 +34,7 @@ import java.util.UUID;
 @RestController
 @EnableWebMvc
 public class PetsController {
+	
     @RequestMapping(path = "/pets", method = RequestMethod.POST)
     public Pet createPet(@RequestBody Pet newPet) {
         if (newPet.getName() == null || newPet.getBreed() == null) {
@@ -73,5 +76,15 @@ public class PetsController {
         newPet.setName(PetData.getRandomName());
         return newPet;
     }
+    
+    @RequestMapping(path = "/foo/{gender}/bar/{age}", method = RequestMethod.POST, produces = MediaType.APPLICATION_JSON_VALUE)
+    public String complexRequest(@RequestBody String body,
+            @PathVariable("gender") String gender,
+            @PathVariable("age") String age,
+            @RequestParam("name") String name
+    ) {
+    	System.out.println("Body: " + body + " - " + gender + "/" + age + "/" + name);
+		return gender + "/" + age + "/" + name;
+	}
 
 }


### PR DESCRIPTION
While concentrating on REST we somehow ignored standard request parameters. This fix addresses it for both v1 and v2 requests as well as adds tests and additional endpoint to a sample to verify

Resolves #754

By submitting this pull request

- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [x] I confirm that I've made a best effort attempt to update all relevant documentation.