### PR TITLE
GH-805 Fix web context initialization during snapstart

### DIFF
--- a/aws-serverless-java-container-springboot3/pom.xml
+++ b/aws-serverless-java-container-springboot3/pom.xml
@@ -25,7 +25,7 @@
         <dependency>
             <groupId>org.springframework.cloud</groupId>
             <artifactId>spring-cloud-function-serverless-web</artifactId>
-            <version>4.0.6</version>
+            <version>4.1.1-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>com.amazonaws.serverless</groupId>

--- a/aws-serverless-java-container-springboot3/src/main/java/com/amazonaws/serverless/proxy/spring/SpringDelegatingLambdaContainerHandler.java
+++ b/aws-serverless-java-container-springboot3/src/main/java/com/amazonaws/serverless/proxy/spring/SpringDelegatingLambdaContainerHandler.java
@@ -53,6 +53,10 @@ public class SpringDelegatingLambdaContainerHandler implements RequestStreamHand
     public SpringDelegatingLambdaContainerHandler(Class<?>... startupClasses) {
         this.startupClasses = startupClasses;
         this.mvc = ServerlessMVC.INSTANCE(this.startupClasses);
+        if (System.getenv().containsKey("AWS_LAMBDA_INITIALIZATION_TYPE") 
+        		&& System.getenv().get("AWS_LAMBDA_INITIALIZATION_TYPE").equals("snap-start")) {
+    		mvc.waitForContext();
+    	}
         this.mapper = new ObjectMapper();
         this.responseWriter = new AwsProxyHttpServletResponseWriter();
     }


### PR DESCRIPTION

#805 

Also updated to s-c-function-serverless-webb 4.1.1-SNAPSHOT This commit forces wait for full context initialization if context is created during snapstart creation

By submitting this pull request

- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [x] I confirm that I've made a best effort attempt to update all relevant documentation.