### PR TITLE
fix: getRemoteHost and getRemotePort for ALB

### DIFF
--- a/aws-serverless-java-container-core/src/main/java/com/amazonaws/serverless/proxy/internal/servlet/AwsHttpServletRequest.java
+++ b/aws-serverless-java-container-core/src/main/java/com/amazonaws/serverless/proxy/internal/servlet/AwsHttpServletRequest.java
@@ -76,6 +76,7 @@ public abstract class AwsHttpServletRequest implements HttpServletRequest {
     static final String PROTOCOL_HEADER_NAME = "X-Forwarded-Proto";
     static final String HOST_HEADER_NAME = "Host";
     static final String PORT_HEADER_NAME = "X-Forwarded-Port";
+    static final String CLIENT_IP_HEADER = "X-Forwarded-For";
 
 
     //-------------------------------------------------------------

--- a/aws-serverless-java-container-core/src/main/java/com/amazonaws/serverless/proxy/internal/servlet/AwsProxyHttpServletRequest.java
+++ b/aws-serverless-java-container-core/src/main/java/com/amazonaws/serverless/proxy/internal/servlet/AwsProxyHttpServletRequest.java
@@ -481,9 +481,10 @@ public class AwsProxyHttpServletRequest extends AwsHttpServletRequest {
     @Override
     public int getRemotePort() {
         if (Objects.nonNull(request.getRequestContext().getElb())) {
-            String hostHeader = request.getHeaders().get(PORT_HEADER_NAME);
-            if (Objects.nonNull(hostHeader))
-                return Integer.parseInt(hostHeader);
+            String portHeader = request.getHeaders().get(PORT_HEADER_NAME);
+            if (Objects.nonNull(portHeader)) {
+                return Integer.parseInt(portHeader);
+            }
         }
         return 0;
     }

--- a/aws-serverless-java-container-core/src/main/java/com/amazonaws/serverless/proxy/internal/servlet/AwsProxyHttpServletRequest.java
+++ b/aws-serverless-java-container-core/src/main/java/com/amazonaws/serverless/proxy/internal/servlet/AwsProxyHttpServletRequest.java
@@ -444,10 +444,10 @@ public class AwsProxyHttpServletRequest extends AwsHttpServletRequest {
     @Override
     public String getRemoteHost() {
         if (Objects.nonNull(request.getRequestContext().getElb())) {
-            String host_header = request.getHeaders().get(HttpHeaders.HOST);
+            String hostHeader = request.getHeaders().get(HttpHeaders.HOST);
 
             // the host header has the form host:port, so we split the string to get the host part
-            return Arrays.asList(host_header.split(":")).get(0);
+            return Arrays.asList(hostHeader.split(":")).get(0);
         }
 
         return request.getMultiValueHeaders().getFirst(HttpHeaders.HOST);
@@ -481,10 +481,9 @@ public class AwsProxyHttpServletRequest extends AwsHttpServletRequest {
     @Override
     public int getRemotePort() {
         if (Objects.nonNull(request.getRequestContext().getElb())) {
-            String hostHeader = request.getHeaders().get(HttpHeaders.HOST);
-            String port = Arrays.asList(hostHeader.split(":")).get(1);
-            if (Objects.nonNull(port))
-                return Integer.parseInt(port);
+            String hostHeader = request.getHeaders().get(PORT_HEADER_NAME);
+            if (Objects.nonNull(hostHeader))
+                return Integer.parseInt(hostHeader);
         }
         return 0;
     }

--- a/aws-serverless-java-container-core/src/main/java/com/amazonaws/serverless/proxy/internal/servlet/AwsProxyHttpServletRequest.java
+++ b/aws-serverless-java-container-core/src/main/java/com/amazonaws/serverless/proxy/internal/servlet/AwsProxyHttpServletRequest.java
@@ -437,6 +437,9 @@ public class AwsProxyHttpServletRequest extends AwsHttpServletRequest {
         if (request.getRequestContext() == null || request.getRequestContext().getIdentity() == null) {
             return "127.0.0.1";
         }
+        if (request.getRequestContext().getElb() != null) {
+            return request.getHeaders().get(CLIENT_IP_HEADER);
+        }
         return request.getRequestContext().getIdentity().getSourceIp();
     }
 

--- a/aws-serverless-java-container-core/src/test/java/com/amazonaws/serverless/proxy/internal/servlet/AwsProxyHttpServletRequestTest.java
+++ b/aws-serverless-java-container-core/src/test/java/com/amazonaws/serverless/proxy/internal/servlet/AwsProxyHttpServletRequestTest.java
@@ -651,6 +651,18 @@ public class AwsProxyHttpServletRequestTest {
         assertEquals("testapi.us-east-1.elb.amazonaws.com", serverName);
     }
 
+    @Test
+    void getRemoteHost_albHostHeader_returnsHostHeader() {
+        initAwsProxyHttpServletRequestTest("ALB");
+        AwsProxyRequest proxyReq = new AwsProxyRequestBuilder("/test", "GET")
+                .alb().build();
+        proxyReq.getHeaders().put(HttpHeaders.HOST, "testapi.us-east-1.elb.amazonaws.com");
+        HttpServletRequest servletRequest = new AwsProxyHttpServletRequest(proxyReq, null, null);
+
+        String host = servletRequest.getRemoteHost();
+        assertEquals("testapi.us-east-1.elb.amazonaws.com", host);
+    }
+
     private AwsProxyRequestBuilder getRequestWithHeaders() {
         return new AwsProxyRequestBuilder("/hello", "GET")
                 .header(CUSTOM_HEADER_KEY, CUSTOM_HEADER_VALUE)

--- a/aws-serverless-java-container-core/src/test/java/com/amazonaws/serverless/proxy/internal/testutils/AwsProxyRequestBuilder.java
+++ b/aws-serverless-java-container-core/src/test/java/com/amazonaws/serverless/proxy/internal/testutils/AwsProxyRequestBuilder.java
@@ -70,7 +70,8 @@ public class AwsProxyRequestBuilder {
 
     public AwsProxyRequestBuilder(String path, String httpMethod) {
         this.request = new AwsProxyRequest();
-        this.request.setMultiValueHeaders(new Headers()); // avoid NPE
+        this.request.setMultiValueHeaders(new Headers());// avoid NPE
+        this.request.setHeaders(new SingleValueHeaders());
         this.request.setHttpMethod(httpMethod);
         this.request.setPath(path);
         this.request.setMultiValueQueryStringParameters(new MultiValuedTreeMap<>());


### PR DESCRIPTION
*Issue #, if available:*  #816

*Description of changes:*
ALB host header information comes in a singleValueHeader object, instead of the multivalueHeaders that was checked.
- Fixed the getRemoteHost and getRemotePort to return the correct values for ALB.
- Added a test to validate.


By submitting this pull request

- [ ] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [ ] I confirm that I've made a best effort attempt to update all relevant documentation.