### PR TITLE
fix: reuse AsyncInitializationWrapper in SpringDelegatingLambdaContainerHandler

### DIFF
--- a/aws-serverless-java-container-springboot3/src/test/java/com/amazonaws/serverless/proxy/spring/SpringDelegatingLambdaContainerHandlerTests.java
+++ b/aws-serverless-java-container-springboot3/src/test/java/com/amazonaws/serverless/proxy/spring/SpringDelegatingLambdaContainerHandlerTests.java
@@ -11,6 +11,7 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 
+import com.amazonaws.serverless.exceptions.ContainerInitializationException;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.cloud.function.serverless.web.ServerlessServletContext;
@@ -200,7 +201,7 @@ public class SpringDelegatingLambdaContainerHandlerTests {
 
     private ObjectMapper mapper = new ObjectMapper();
 
-    public void initServletAppTest()  {
+    public void initServletAppTest() throws ContainerInitializationException {
         this.handler = new SpringDelegatingLambdaContainerHandler(ServletApplication.class);
     }
 


### PR DESCRIPTION
*Issue #, if available:*
#758 

*Description of changes:*
Did some testing with this app https://github.com/aws-samples/aws-lambda-java-workshop/tree/main/labs/unicorn-store/software/unicorn-store-spring and 512 MB memory.
Comparison between
old `StreamLambdaHandler` implementation: Duration: 648.79 ms	Billed Duration: 649 ms	Memory Size: 1024 MB	Max Memory Used: 333 MB	Init Duration: 9747.09 ms
and
new `SpringDelegatingLambdaContainerHandler` Duration: 16626.82 ms	Billed Duration: 16627 ms	Memory Size: 1024 MB	Max Memory Used: 330 MB	Init Duration: 1344.65 ms	

With this change the init is done properly. Threading still needs to be removed from SCF.

By submitting this pull request

- [X] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [X] I confirm that I've made a best effort attempt to update all relevant documentation.