### PR TITLE
fix: Error with version 2.0.2 when multi-value header is active in alb

### DIFF
--- a/aws-serverless-java-container-core/src/test/java/com/amazonaws/serverless/proxy/internal/servlet/AwsProxyHttpServletRequestTest.java
+++ b/aws-serverless-java-container-core/src/test/java/com/amazonaws/serverless/proxy/internal/servlet/AwsProxyHttpServletRequestTest.java
@@ -652,11 +652,25 @@ public class AwsProxyHttpServletRequestTest {
     }
 
     @Test
-    void getRemoteHost_albHostHeader_returnsHostHeader() {
+    void getRemoteHost_albHostHeader_singleValue_returnsHostHeader() {
         initAwsProxyHttpServletRequestTest("ALB");
         AwsProxyRequest proxyReq = new AwsProxyRequestBuilder("/test", "GET")
                 .alb().build();
+        proxyReq.setMultiValueHeaders(null);
         proxyReq.getHeaders().put(HttpHeaders.HOST, "testapi.us-east-1.elb.amazonaws.com");
+        HttpServletRequest servletRequest = new AwsProxyHttpServletRequest(proxyReq, null, null);
+
+        String host = servletRequest.getRemoteHost();
+        assertEquals("testapi.us-east-1.elb.amazonaws.com", host);
+    }
+
+    @Test
+    void getRemoteHost_albHostHeader_multiValue_returnsHostHeader() {
+        initAwsProxyHttpServletRequestTest("ALB");
+        AwsProxyRequest proxyReq = new AwsProxyRequestBuilder("/test", "GET")
+                .header(HttpHeaders.HOST, "testapi.us-east-1.elb.amazonaws.com")
+                .alb().build();
+        proxyReq.setHeaders(null);
         HttpServletRequest servletRequest = new AwsProxyHttpServletRequest(proxyReq, null, null);
 
         String host = servletRequest.getRemoteHost();


### PR DESCRIPTION
*Issue #, if available:* #909

*Description of changes:*
Fixes bug introduced by #827
When using Lambda as target in ALB, Customers can configure either multi-value or single value headers. host header information then comes in either a singleValueHeader object or a multivalueHeaders object.
This PR adds support for both object types.

- Fixed the getRemoteHost and getRemotePort to return the correct values for ALB.
- Added a test to validate.


By submitting this pull request

- [ ] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [ ] I confirm that I've made a best effort attempt to update all relevant documentation.