### PR TITLE
Add reflection-metadata for Lambda Function URL

### DIFF
--- a/aws-serverless-java-container-core/src/main/resources/native-image/reflect-config.json
+++ b/aws-serverless-java-container-core/src/main/resources/native-image/reflect-config.json
@@ -1,0 +1,32 @@
+[
+  {
+    "name": "com.amazonaws.serverless.proxy.model.HttpApiV2ProxyRequest",
+    "allDeclaredConstructors": true,
+    "allDeclaredFields": true,
+    "allDeclaredMethods": true
+  },
+  {
+    "name": "com.amazonaws.serverless.proxy.model.HttpApiV2ProxyRequestContext",
+    "allDeclaredConstructors": true,
+    "allDeclaredFields": true,
+    "allDeclaredMethods": true
+  },
+  {
+    "name": "com.amazonaws.serverless.proxy.model.HttpApiV2AuthorizerMap",
+    "allDeclaredConstructors": true,
+    "allDeclaredFields": true,
+    "allDeclaredMethods": true
+  },
+  {
+    "name": "com.amazonaws.serverless.proxy.model.HttpApiV2AuthorizerMap$HttpApiV2AuthorizerDeserializer",
+    "allDeclaredConstructors": true,
+    "allDeclaredFields": true,
+    "allDeclaredMethods": true
+  },
+  {
+    "name": "com.amazonaws.serverless.proxy.model.HttpApiV2HttpContext",
+    "allDeclaredConstructors": true,
+    "allDeclaredFields": true,
+    "allDeclaredMethods": true
+  }
+]


### PR DESCRIPTION
*Issue #, if available:*
When I deployed the serverless-java-container for a Spring Boot 3 application with Java 21 compiled with GraalVM Native Image I got exceptions in the following format when requesting AWS Lambda by Function URL:
```text
ERROR 10 --- [pool-5-thread-1] s.p.s.AwsSpringWebCustomRuntimeEventLoop : java.lang.IllegalStateException: com.fasterxml.jackson.databind.exc.InvalidDefinitionException: Class com.amazonaws.serverless.proxy.model.HttpApiV2AuthorizerMap$HttpApiV2AuthorizerDeserializer has no default (no arg) constructor
at [Source: REDACTED (`StreamReadFeature.INCLUDE_SOURCE_IN_LOCATION` disabled); line: 1, column: 1] 
```

*Description of changes:*
Added required GraalVM reflection metadata to resolve exceptions.

By submitting this pull request
- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [x] I confirm that I've made a best effort attempt to update all relevant documentation.