### PR TITLE
fix: parameters encoding doesn't work for ALB when using Spring Cloud

### DIFF
--- a/aws-serverless-java-container-core/src/main/java/com/amazonaws/serverless/proxy/internal/servlet/AwsHttpServletRequest.java
+++ b/aws-serverless-java-container-core/src/main/java/com/amazonaws/serverless/proxy/internal/servlet/AwsHttpServletRequest.java
@@ -546,7 +546,7 @@ public abstract class AwsHttpServletRequest implements HttpServletRequest {
         return value.toArray(new String[0]);
     }
 
-    protected List<String> getQueryParamValuesAsList(MultiValuedTreeMap<String, String> qs, String key, boolean isCaseSensitive) {
+    public static List<String> getQueryParamValuesAsList(MultiValuedTreeMap<String, String> qs, String key, boolean isCaseSensitive) {
         if (qs != null) {
             if (isCaseSensitive) {
                 return qs.get(key);
@@ -788,7 +788,7 @@ public abstract class AwsHttpServletRequest implements HttpServletRequest {
         return finalUri;
     }
 
-    static String decodeValueIfEncoded(String value) {
+    public static String decodeValueIfEncoded(String value) {
         if (value == null) {
             return null;
         }

--- a/aws-serverless-java-container-springboot3/src/test/java/com/amazonaws/serverless/proxy/spring/AwsSpringHttpProcessingUtilsTests.java
+++ b/aws-serverless-java-container-springboot3/src/test/java/com/amazonaws/serverless/proxy/spring/AwsSpringHttpProcessingUtilsTests.java
@@ -6,6 +6,7 @@ import java.util.Arrays;
 import java.util.Collection;
 
 import com.amazonaws.serverless.proxy.RequestReader;
+import com.amazonaws.serverless.proxy.model.AlbContext;
 import com.amazonaws.serverless.proxy.model.HttpApiV2ProxyRequest;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
@@ -194,7 +195,7 @@ public class AwsSpringHttpProcessingUtilsTests {
 			"    },\n" +
 			"    \"httpMethod\": \"POST\",\n" +
 			"    \"path\": \"/async\",\n" +
-			"    \"multiValueQueryStringParameters\": { \"parameter1\": [\"value1\", \"value2\"]},\n" +
+			"    \"multiValueQueryStringParameters\": { \"parameter1\": [\"value1\", \"value2\"], \"parameter2\": [\"1970-01-01T00%3A00%3A00.004Z\"]},\n" +
 			"    \"multiValueHeaders\": {\n" +
 			"        \"accept\": [\"text/html,application/xhtml+xml\"],\n" +
 			"        \"accept-language\": [\"en-US,en;q=0.8\"],\n" +
@@ -237,6 +238,10 @@ public class AwsSpringHttpProcessingUtilsTests {
 		if (!(request.getAttribute(RequestReader.HTTP_API_EVENT_PROPERTY) instanceof HttpApiV2ProxyRequest)) {
 			assertEquals("value1", request.getParameter("parameter1"));
 			assertArrayEquals(new String[]{"value1", "value2"}, request.getParameterValues("parameter1"));
+		}
+		if (request.getAttribute(RequestReader.ALB_CONTEXT_PROPERTY) instanceof AlbContext) {
+			// query params should be decoded
+			assertEquals("1970-01-01T00:00:00.004Z", request.getParameter("parameter2"));
 		}
 	}
     


### PR DESCRIPTION
*Issue #, if available:* #1279

#### Description of changes: 
Added parameter decoding for ALB when using Spring Cloud.

#### Context:

When an ALB receives a request with URL-encoded query parameters, it passes those parameters to the Lambda function exactly as they were received, with the encoding intact. For example:

• Original URL: https://example.com/path?time=1970-01-01T00%3A00%3A00.004Z
• In the ALB event sent to Lambda: "time": "1970-01-01T00%3A00%3A00.004Z"

The %3A (representing :) remains encoded in the query parameter value.
This behavior differs from API Gateway, which automatically decodes URL-encoded query parameters before including them in the event object sent to Lambda functions. 

Currently when we use the classic way of mapping request events to servlet requests, things work fine as the decoding of queryStringParameters is properly handled for ALB. However, when using the new Spring Cloud (AwsSpringHttpProcessingUtils), the parameters are not decoded. This PR fixes the issue.

#### Note: Ideally, this decoding logic should reside inside the [ServerlessHttpServletRequest](https://github.com/spring-cloud/spring-cloud-function/blob/ba2db77f8045c927ac8caa35d036afbabdeaebbc/spring-cloud-function-adapters/spring-cloud-function-serverless-web/src/main/java/org/springframework/cloud/function/serverless/web/ServerlessHttpServletRequest.java#L426-L446) the same way it's done in [AwsProxyHttpServletRequest](https://github.com/spring-cloud/spring-cloud-function/blob/ba2db77f8045c927ac8caa35d036afbabdeaebbc/spring-cloud-function-adapters/spring-cloud-function-serverless-web/src/main/java/org/springframework/cloud/function/serverless/web/ServerlessHttpServletRequest.java#L426-L446)

By submitting this pull request

- [ ] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [ ] I confirm that I've made a best effort attempt to update all relevant documentation.