### PR TITLE
"chore(deps-dev): bump jakarta.validation:jakarta.validation-api from 3.0.2 to 3.1.1"

### DIFF
--- a/aws-serverless-java-container-springboot3/pom.xml
+++ b/aws-serverless-java-container-springboot3/pom.xml
@@ -173,7 +173,7 @@
         <dependency>
             <groupId>jakarta.validation</groupId>
             <artifactId>jakarta.validation-api</artifactId>
-            <version>3.1.1</version>
+            <version>3.0.2</version>
             <scope>test</scope>
         </dependency>
 


### PR DESCRIPTION
Reverts aws/serverless-java-container#1264