### PR TITLE
Update Dependency: commons-fileupload2-jakarta-servlet6 to 2.0.0-M4

### DIFF
--- a/aws-serverless-java-container-core/pom.xml
+++ b/aws-serverless-java-container-core/pom.xml
@@ -54,7 +54,7 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-fileupload2-jakarta-servlet6</artifactId>
-            <version>2.0.0-M2</version>
+            <version>2.0.0-M4</version>
         </dependency>
 
         <dependency>

--- a/aws-serverless-java-container-core/src/main/java/com/amazonaws/serverless/proxy/internal/servlet/AwsHttpServletRequest.java
+++ b/aws-serverless-java-container-core/src/main/java/com/amazonaws/serverless/proxy/internal/servlet/AwsHttpServletRequest.java
@@ -511,15 +511,15 @@ public abstract class AwsHttpServletRequest implements HttpServletRequest {
             List<DiskFileItem> items = upload.parseRequest(this);
             for (FileItem<DiskFileItem> item : items) {
                 String fileName = FilenameUtils.getName(item.getName());
-                    AwsProxyRequestPart newPart = new AwsProxyRequestPart(item.get());
-                    newPart.setName(item.getFieldName());
-                    newPart.setSubmittedFileName(fileName);
-                    newPart.setContentType(item.getContentType());
-                    newPart.setSize(item.getSize());
-                    item.getHeaders().getHeaderNames().forEachRemaining(h -> {
-                        newPart.addHeader(h, item.getHeaders().getHeader(h));
-                    });
-                    addPart(multipartFormParameters, item.getFieldName(), newPart);
+                AwsProxyRequestPart newPart = new AwsProxyRequestPart(item.get());
+                newPart.setName(item.getFieldName());
+                newPart.setSubmittedFileName(fileName);
+                newPart.setContentType(item.getContentType());
+                newPart.setSize(item.getSize());
+                item.getHeaders().getHeaderNames().forEachRemaining(h -> {
+                    newPart.addHeader(h, item.getHeaders().getHeader(h));
+                });
+                addPart(multipartFormParameters, item.getFieldName(), newPart);
             }
         } catch (FileUploadException e) {
             Timer.stop("SERVLET_REQUEST_GET_MULTIPART_PARAMS");

--- a/aws-serverless-java-container-core/src/main/java/com/amazonaws/serverless/proxy/internal/servlet/AwsHttpServletRequest.java
+++ b/aws-serverless-java-container-core/src/main/java/com/amazonaws/serverless/proxy/internal/servlet/AwsHttpServletRequest.java
@@ -493,7 +493,7 @@ public abstract class AwsHttpServletRequest implements HttpServletRequest {
     }
 
     @SuppressFBWarnings({"FILE_UPLOAD_FILENAME", "WEAK_FILENAMEUTILS"})
-    protected Map<String, List<Part>> getMultipartFormParametersMap() throws RuntimeException {
+    protected Map<String, List<Part>> getMultipartFormParametersMap() throws IOException {
         if (multipartFormParameters != null) {
             return multipartFormParameters;
         }
@@ -523,7 +523,7 @@ public abstract class AwsHttpServletRequest implements HttpServletRequest {
                     addPart(multipartFormParameters, item.getFieldName(), newPart);
                 } catch (IOException e) {
                     log.error("Encounter issue adding form multipart", e);
-                    throw new RuntimeException(e);
+                    throw new IOException(e);
                 }
             }
         } catch (FileUploadException e) {

--- a/aws-serverless-java-container-core/src/main/java/com/amazonaws/serverless/proxy/internal/servlet/AwsHttpServletRequest.java
+++ b/aws-serverless-java-container-core/src/main/java/com/amazonaws/serverless/proxy/internal/servlet/AwsHttpServletRequest.java
@@ -511,7 +511,6 @@ public abstract class AwsHttpServletRequest implements HttpServletRequest {
             List<DiskFileItem> items = upload.parseRequest(this);
             for (FileItem<DiskFileItem> item : items) {
                 String fileName = FilenameUtils.getName(item.getName());
-                try {
                     AwsProxyRequestPart newPart = new AwsProxyRequestPart(item.get());
                     newPart.setName(item.getFieldName());
                     newPart.setSubmittedFileName(fileName);
@@ -521,10 +520,6 @@ public abstract class AwsHttpServletRequest implements HttpServletRequest {
                         newPart.addHeader(h, item.getHeaders().getHeader(h));
                     });
                     addPart(multipartFormParameters, item.getFieldName(), newPart);
-                } catch (IOException e) {
-                    log.error("Encounter issue adding form multipart", e);
-                    throw new IOException(e);
-                }
             }
         } catch (FileUploadException e) {
             Timer.stop("SERVLET_REQUEST_GET_MULTIPART_PARAMS");

--- a/aws-serverless-java-container-core/src/main/java/com/amazonaws/serverless/proxy/internal/servlet/AwsHttpServletRequest.java
+++ b/aws-serverless-java-container-core/src/main/java/com/amazonaws/serverless/proxy/internal/servlet/AwsHttpServletRequest.java
@@ -517,7 +517,10 @@ public abstract class AwsHttpServletRequest implements HttpServletRequest {
                 newPart.setContentType(item.getContentType());
                 newPart.setSize(item.getSize());
                 item.getHeaders().getHeaderNames().forEachRemaining(h -> {
-                    newPart.addHeader(h, item.getHeaders().getHeader(h));
+                    String headerValue = item.getHeaders().getHeader(h);
+                    if (headerValue != null) {
+                        newPart.addHeader(h, headerValue);
+                    }
                 });
 
                 addPart(multipartFormParameters, item.getFieldName(), newPart);

--- a/aws-serverless-java-container-core/src/main/java/com/amazonaws/serverless/proxy/internal/servlet/AwsHttpServletRequest.java
+++ b/aws-serverless-java-container-core/src/main/java/com/amazonaws/serverless/proxy/internal/servlet/AwsHttpServletRequest.java
@@ -521,7 +521,7 @@ public abstract class AwsHttpServletRequest implements HttpServletRequest {
                         newPart.addHeader(h, item.getHeaders().getHeader(h));
                     });
                     addPart(multipartFormParameters, item.getFieldName(), newPart);
-                } catch (Exception e) {
+                } catch (IOException e) {
                     log.error("Encounter issue adding form multipart", e);
                     throw new RuntimeException(e);
                 }


### PR DESCRIPTION
This is to update dependency on commons-fileupload2-core from 2.0.0-M2 to 2.0.0-M4


By submitting this pull request
- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [x] I confirm that I've made the best effort attempt to update all relevant documentation.