### PR TITLE
fix: headers with null values removed from response

### DIFF
--- a/aws-serverless-java-container-core/src/main/java/com/amazonaws/serverless/proxy/internal/servlet/AwsHttpServletResponse.java
+++ b/aws-serverless-java-container-core/src/main/java/com/amazonaws/serverless/proxy/internal/servlet/AwsHttpServletResponse.java
@@ -496,9 +496,12 @@ public class AwsHttpServletResponse
             values = new ArrayList<>();
         }
 
-        values.add(encodedValue);
-
-        headers.put(encodedKey, values);
+        if (value == null && overwrite) {
+            headers.remove(encodedKey);
+        } else if (value != null) {
+            values.add(encodedValue);
+            headers.put(encodedKey, values);
+        }
     }
 
     private boolean canSetHeader() {

--- a/aws-serverless-java-container-core/src/test/java/com/amazonaws/serverless/proxy/internal/servlet/AwsHttpServletResponseTest.java
+++ b/aws-serverless-java-container-core/src/test/java/com/amazonaws/serverless/proxy/internal/servlet/AwsHttpServletResponseTest.java
@@ -174,6 +174,16 @@ public class AwsHttpServletResponseTest {
     }
 
     @Test
+    void responseHeaders_setHeaderWithNullValue_expectHeaderRemoved() {
+        AwsHttpServletResponse resp = new AwsHttpServletResponse(null, null);
+        resp.setHeader(HttpHeaders.CONTENT_DISPOSITION, "inline");
+        resp.setHeader(HttpHeaders.CONTENT_DISPOSITION, null);
+
+        Headers awsResp = resp.getAwsResponseHeaders();
+        assertEquals(0, awsResp.size());
+    }
+
+    @Test
     void responseHeaders_getAwsResponseHeaders_expectedMultpleCookieHeaders() {
         AwsHttpServletResponse resp = new AwsHttpServletResponse(null, null);
         resp.addCookie(new Cookie(COOKIE_NAME, COOKIE_VALUE));


### PR DESCRIPTION
Issue #1522

* remove response header if set with `null` value. 
* ignore `null` values when added to response header


By submitting this pull request

- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [x] I confirm that I've made a best effort attempt to update all relevant documentation.