### PR TITLE
Fix Spring AotInitializerNotFoundException with AOT

### DIFF
--- a/aws-serverless-java-container-springboot3/src/main/java/com/amazonaws/serverless/proxy/spring/SpringBootLambdaContainerHandler.java
+++ b/aws-serverless-java-container-springboot3/src/main/java/com/amazonaws/serverless/proxy/spring/SpringBootLambdaContainerHandler.java
@@ -184,13 +184,16 @@ public class SpringBootLambdaContainerHandler<RequestType, ResponseType> extends
         Timer.stop("SPRINGBOOT2_HANDLE_REQUEST");
     }
 
+    SpringApplicationBuilder getSpringApplicationBuilder(Class<?>... sources) {
+        return new SpringApplicationBuilder(sources);
+    }
 
     @Override
     public void initialize()
             throws ContainerInitializationException {
         Timer.start("SPRINGBOOT2_COLD_START");
 
-        SpringApplicationBuilder builder = new SpringApplicationBuilder(getEmbeddedContainerClasses())
+        SpringApplicationBuilder builder = getSpringApplicationBuilder(getEmbeddedContainerClasses())
                 .web(springWebApplicationType); // .REACTIVE, .SERVLET
         if(springBootInitializer != null) {
             builder.main(springBootInitializer);

--- a/aws-serverless-java-container-springboot3/src/test/java/com/amazonaws/serverless/proxy/spring/SpringBootLambdaContainerHandlerTest.java
+++ b/aws-serverless-java-container-springboot3/src/test/java/com/amazonaws/serverless/proxy/spring/SpringBootLambdaContainerHandlerTest.java
@@ -1,0 +1,76 @@
+package com.amazonaws.serverless.proxy.spring;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import com.amazonaws.serverless.exceptions.ContainerInitializationException;
+import com.amazonaws.serverless.proxy.AwsProxyExceptionHandler;
+import com.amazonaws.serverless.proxy.AwsProxySecurityContextWriter;
+import com.amazonaws.serverless.proxy.InitializationWrapper;
+import com.amazonaws.serverless.proxy.internal.servlet.AwsProxyHttpServletRequestReader;
+import com.amazonaws.serverless.proxy.internal.servlet.AwsProxyHttpServletResponseWriter;
+import com.amazonaws.serverless.proxy.model.AwsProxyRequest;
+import com.amazonaws.serverless.proxy.model.AwsProxyResponse;
+import com.amazonaws.serverless.proxy.spring.servletapp.ServletApplication;
+import com.amazonaws.serverless.proxy.spring.webfluxapp.WebFluxTestApplication;
+import java.util.Collection;
+import java.util.List;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.Mockito;
+import org.springframework.boot.WebApplicationType;
+import org.springframework.boot.builder.SpringApplicationBuilder;
+
+class SpringBootLambdaContainerHandlerTest {
+
+    SpringBootLambdaContainerHandler<AwsProxyRequest, AwsProxyResponse> handler;
+    SpringApplicationBuilder springApplicationBuilder;
+
+    public static Collection<TestData> data() {
+        return List.of(new TestData(WebApplicationType.SERVLET, ServletApplication.class),
+            new TestData(WebApplicationType.REACTIVE, WebFluxTestApplication.class));
+    }
+
+    private void initSpringBootLambdaContainerHandlerTest(Class<?> springBootInitializer,
+        WebApplicationType applicationType) {
+        handler = Mockito.spy(new SpringBootLambdaContainerHandler<>(AwsProxyRequest.class,
+            AwsProxyResponse.class,
+            new AwsProxyHttpServletRequestReader(),
+            new AwsProxyHttpServletResponseWriter(),
+            new AwsProxySecurityContextWriter(),
+            new AwsProxyExceptionHandler(),
+            springBootInitializer,
+            new InitializationWrapper(),
+            applicationType));
+
+        doAnswer(d -> {
+            springApplicationBuilder = ((SpringApplicationBuilder) Mockito.spy(d.callRealMethod()));
+            return springApplicationBuilder;
+        }).when(handler).getSpringApplicationBuilder(any(Class[].class));
+    }
+
+    @ParameterizedTest
+    @MethodSource("data")
+    void initialize_withSpringBootInitializer(TestData data) throws ContainerInitializationException {
+        initSpringBootLambdaContainerHandlerTest(data.springBootApplication(), data.applicationType());
+        handler.initialize();
+
+        verify(springApplicationBuilder, times(1)).main(data.springBootApplication());
+    }
+
+    @ParameterizedTest
+    @EnumSource(WebApplicationType.class)
+    void initialize_withoutSpringBootInitializer(WebApplicationType webApplicationType) {
+        initSpringBootLambdaContainerHandlerTest(null, webApplicationType);
+        assertThrows(IllegalArgumentException.class, handler::initialize, "Source must not be null");
+
+        verify(springApplicationBuilder, never()).main(any());
+    }
+
+    record TestData(WebApplicationType applicationType, Class<?> springBootApplication) {}
+}


### PR DESCRIPTION
fix: added missing main class to SpringApplicationBuilder (#1580)
fix: replaced `AnnotationConfigServletWebServerApplicationContext` with `ConfigurableWebApplicationContext` (#1580)

*Issue #, if available:*

*Description of changes:*


By submitting this pull request

- [x] I confirm that my contribution is made under the terms of the Apache 2.0 license.
- [x] I confirm that I've made a best effort attempt to update all relevant documentation.