### PR TITLE
Add unit tests for AwsProxyExceptionHandler

### DIFF
--- a/aws-serverless-java-container-core/src/test/java/com/amazonaws/serverless/proxy/AwsProxyExceptionHandlerTest.java
+++ b/aws-serverless-java-container-core/src/test/java/com/amazonaws/serverless/proxy/AwsProxyExceptionHandlerTest.java
@@ -3,6 +3,7 @@ package com.amazonaws.serverless.proxy;
 
 import com.amazonaws.serverless.exceptions.InvalidRequestEventException;
 import com.amazonaws.serverless.exceptions.InvalidResponseObjectException;
+import com.amazonaws.serverless.proxy.internal.LambdaContainerHandler;
 import com.amazonaws.serverless.proxy.model.AwsProxyResponse;
 import com.amazonaws.serverless.proxy.model.ErrorModel;
 import tools.jackson.core.JacksonException;
@@ -11,10 +12,12 @@ import tools.jackson.databind.ObjectMapper;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.when;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 
 import jakarta.ws.rs.InternalServerErrorException;
@@ -256,5 +259,38 @@ public class AwsProxyExceptionHandlerTest {
         ErrorModel error = objectMapper.readValue(output, ErrorModel.class);
         assertNotNull(error);
         assertEquals(INVALID_RESPONSE_MESSAGE, error.getMessage());
+    }
+
+    @Test
+    void handle_printStackTraceCalled() {
+        // Capture System.err to verify printStackTrace() is invoked
+        PrintStream originalErr = System.err;
+        ByteArrayOutputStream errCapture = new ByteArrayOutputStream();
+        System.setErr(new PrintStream(errCapture));
+
+        try {
+            exceptionHandler.handle(new RuntimeException("test"));
+
+            assertTrue(errCapture.size() > 0, "printStackTrace should write to stderr");
+            String errOutput = errCapture.toString();
+            assertTrue(errOutput.contains("RuntimeException"), "stderr should contain exception class name");
+        } finally {
+            System.setErr(originalErr);
+        }
+    }
+
+    @Test
+    void getErrorJson_JacksonException_fallbackJson() {
+        ObjectMapper mockMapper = mock(ObjectMapper.class);
+        JacksonException exception = mock(JacksonException.class);
+        when(mockMapper.writeValueAsString(any(Object.class))).thenThrow(exception);
+
+        try (MockedStatic<LambdaContainerHandler> mockedHandler = mockStatic(LambdaContainerHandler.class)) {
+            mockedHandler.when(LambdaContainerHandler::getObjectMapper).thenReturn(mockMapper);
+
+            String output = exceptionHandler.getErrorJson("test error");
+
+            assertEquals("{ \"message\": \"test error\" }", output);
+        }
     }
 }


### PR DESCRIPTION
Additive unit tests for `AwsProxyExceptionHandler` — edge cases and current behavior pinned with explicit assertions. No existing test or production code changed.

Verified green under Java 17 (`mvn -pl aws-serverless-java-container-core test -Dtest=AwsProxyExceptionHandlerTest` → Tests run: 22, Failures: 0, Errors: 0).



---

**How this was produced**

This PR was generated with an AI-assisted pipeline built around mutation testing (PIT). The pipeline mutates the target class (flipping conditions and changing boundary/edge cases) and runs the existing tests against each mutant. Where a mutant survives (the existing tests do not catch that edge case), it writes a focused test for that case and reruns PIT to confirm the new test actually kills that specific mutant. So every added test is verified to catch a concrete edge case the suite missed before, rather than being speculative or redundant. The change is additive only (no production code modified), and the module builds green under its CI JDK.
